### PR TITLE
fix: correct deployment workflow command syntax

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies & Restart server
         run: |
           cd /polarag_backend
-          RUN pip install --upgrade uv
+          pip install --upgrade uv
           uv sync
           pm2 reload backend
           echo "🚀 Backend server restarted."


### PR DESCRIPTION
Fixed the deployment workflow by removing an incorrect 'RUN' keyword from the pip install command to ensure dependencies install properly during the GitHub Actions deployment process.