### PR TITLE
chore: Add 'test' directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,4 @@ trash/persistent_config_backup.py
 trash/persistent_config_new.py
 
 backup
+test


### PR DESCRIPTION
Include the 'test' directory in the .gitignore file to prevent test-related files from being tracked by Git. This helps keep the repository clean from temporary or local test artifacts.