### PR TITLE
fix: Add strict citation handling in prompt construction

### DIFF
--- a/editor/nodes/xgen/agent/agent_vllm_stream.py
+++ b/editor/nodes/xgen/agent/agent_vllm_stream.py
@@ -136,9 +136,9 @@ class AgentVLLMStreamNode(Node):
                 default_prompt = f"{default_prompt}\n\n{escaped_instructions}"
 
             if tools_list:
+                if strict_citation:
+                    default_prompt = default_prompt + citation_prompt+"<tool_reponse> 태그가 없다면 출처표기를 하지마세요"
                 if additional_rag_context and additional_rag_context.strip():
-                    if strict_citation:
-                        default_prompt = default_prompt + citation_prompt
                     final_prompt = ChatPromptTemplate.from_messages([
                         ("system", default_prompt),
                         MessagesPlaceholder(variable_name="chat_history", n_messages=n_messages),


### PR DESCRIPTION
Added logic to append a citation instruction to the default prompt when strict_citation is enabled, ensuring that sources are only cited if the <tool_reponse> tag is present. This change improves prompt accuracy and citation control in the AgentVLLMStreamNode.