### PR TITLE
feat: Add strict citation enforcement to agent prompts

### DIFF
--- a/editor/nodes/xgen/agent/agent_kt_midm.py
+++ b/editor/nodes/xgen/agent/agent_kt_midm.py
@@ -221,9 +221,9 @@ class AgentKTNode(Node):
             }
 
             if tools is not None:
+                if strict_citation:
+                    prompt = prompt + citation_prompt+"<tool_reponse> 태그가 없다면 출처표기를 하지마세요"
                 if additional_rag_context and additional_rag_context.strip():
-                    if strict_citation:
-                        prompt = prompt + citation_prompt
                     final_prompt = ChatPromptTemplate.from_messages([
                         ("system", prompt),
                         MessagesPlaceholder(variable_name="chat_history", n_messages=n_messages),

--- a/editor/nodes/xgen/agent/agent_kt_midm_stream.py
+++ b/editor/nodes/xgen/agent/agent_kt_midm_stream.py
@@ -138,9 +138,9 @@ class AgentKTStreamNode(Node):
                 default_prompt = f"{default_prompt}\n\n{escaped_instructions}"
 
             if tools_list:
+                if strict_citation:
+                    default_prompt = default_prompt + citation_prompt + "<tool_reponse> 태그가 없다면 출처표기를 하지마세요"
                 if additional_rag_context and additional_rag_context.strip():
-                    if strict_citation:
-                        default_prompt = default_prompt + citation_prompt
                     final_prompt = ChatPromptTemplate.from_messages([
                         ("system", default_prompt),
                         MessagesPlaceholder(variable_name="chat_history", n_messages=n_messages),

--- a/editor/nodes/xgen/agent/agent_openai.py
+++ b/editor/nodes/xgen/agent/agent_openai.py
@@ -185,9 +185,9 @@ class AgentOpenAINode(Node):
             }
 
             if tools is not None:
+                if strict_citation:
+                    prompt = prompt + citation_prompt+"<tool_reponse> 태그가 없다면 출처표기를 하지마세요"
                 if additional_rag_context and additional_rag_context.strip():
-                    if strict_citation:
-                        prompt = prompt + citation_prompt
                     if args_schema:
                         parser = JsonOutputParser(pydantic_object=args_schema)
                         format_instructions = parser.get_format_instructions()

--- a/editor/nodes/xgen/agent/agent_openai_stream.py
+++ b/editor/nodes/xgen/agent/agent_openai_stream.py
@@ -124,9 +124,9 @@ class AgentOpenAIStreamNode(Node):
                 default_prompt = f"{default_prompt}\n\n{escaped_instructions}"
 
             if tools_list:
+                if strict_citation:
+                    default_prompt = default_prompt + citation_prompt+"<tool_reponse> 태그가 없다면 출처표기를 하지마세요"
                 if additional_rag_context and additional_rag_context.strip():
-                    if strict_citation:
-                        default_prompt = default_prompt + citation_prompt
                     final_prompt = ChatPromptTemplate.from_messages([
                         ("system", default_prompt),
                         MessagesPlaceholder(variable_name="chat_history", n_messages=n_messages),

--- a/editor/nodes/xgen/agent/agent_openai_stream_react.py
+++ b/editor/nodes/xgen/agent/agent_openai_stream_react.py
@@ -124,9 +124,9 @@ class AgentOpenAIStreamNode(Node):
                 default_prompt = f"{default_prompt}\n\n{escaped_instructions}"
 
             if tools_list:
+                if strict_citation:
+                    default_prompt = default_prompt + citation_prompt+"<tool_reponse> 태그가 없다면 출처표기를 하지마세요"
                 if additional_rag_context and additional_rag_context.strip():
-                    if strict_citation:
-                        default_prompt = default_prompt + citation_prompt
                     final_prompt = ChatPromptTemplate.from_messages([
                         ("system", default_prompt),
                         MessagesPlaceholder(variable_name="chat_history", n_messages=n_messages),

--- a/editor/nodes/xgen/agent/agent_vllm.py
+++ b/editor/nodes/xgen/agent/agent_vllm.py
@@ -215,9 +215,9 @@ class AgentVLLMNode(Node):
             }
 
             if tools is not None:
+                if strict_citation:
+                    prompt = prompt + citation_prompt+"<tool_reponse> 태그가 없다면 출처표기를 하지마세요"
                 if additional_rag_context and additional_rag_context.strip():
-                    if strict_citation:
-                        prompt = prompt + citation_prompt
                     if args_schema:
                         parser = JsonOutputParser(pydantic_object=args_schema)
                         format_instructions = parser.get_format_instructions()

--- a/editor/nodes/xgen/agent/agent_vllm_stream_react.py
+++ b/editor/nodes/xgen/agent/agent_vllm_stream_react.py
@@ -137,9 +137,9 @@ class AgentVLLMStreamNode(Node):
                 default_prompt = f"{default_prompt}\n\n{escaped_instructions}"
 
             if tools_list:
+                if strict_citation:
+                    default_prompt = default_prompt + citation_prompt+"<tool_reponse> 태그가 없다면 출처표기를 하지마세요"
                 if additional_rag_context and additional_rag_context.strip():
-                    if strict_citation:
-                        default_prompt = default_prompt + citation_prompt
                     final_prompt = ChatPromptTemplate.from_messages([
                         ("system", default_prompt),
                         MessagesPlaceholder(variable_name="chat_history", n_messages=n_messages),


### PR DESCRIPTION
Enhance prompt construction in multiple agent nodes to append a strict citation instruction when `strict_citation` is enabled. This instruction includes a note to omit citation if the `<tool_reponse>` tag is missing, ensuring clearer source attribution requirements during generation.

- Updated prompt handling in agent_kt_midm, agent_kt_midm_stream, agent_openai, agent_openai_stream, agent_openai_stream_react, agent_vllm, and agent_vllm_stream_react nodes.
- Removed redundant conditional prompt additions for strict citation when additional RAG context is present.
- Standardized citation prompt suffix across all affected nodes.