### PR TITLE
fix: Remove debug prints and correct access path check

### DIFF
--- a/controller/documentController.py
+++ b/controller/documentController.py
@@ -208,29 +208,17 @@ async def fetch_document(
         
         # 파일 경로 검증
         decoded_path = urllib.parse.unquote(document_request.file_path)
-        print(f"1. decoded_path: {repr(decoded_path)}")
-
         dir_part, file_part = os.path.split(decoded_path)
-        print(f"2. dir_part: {repr(dir_part)}")
-        print(f"3. file_part: {repr(file_part)}")
-
         normalized_file = unicodedata.normalize('NFD', file_part)
-        print(f"4. normalized_file: {repr(normalized_file)}")
-        print(f"5. normalized_file bytes: {normalized_file.encode('utf-8')}")
-
         joined_path = os.path.join(dir_part, normalized_file)
-        print(f"6. joined_path: {repr(joined_path)}")
-
         safe_path = validate_file_path(joined_path, DOCUMENTS_BASE_DIR)
-        print(f"7. safe_path: {safe_path}")
-        print(f"8. file exists: {os.path.exists(safe_path)}")
         
         # 접근 권한 확인
         app_db = request.app.state.app_db
         if not app_db:
             raise HTTPException(status_code=500, detail="Database connection not available")
         
-        access_check = await check_document_access(app_db, user_id, decoded_path)
+        access_check = await check_document_access(app_db, user_id, joined_path)
         if not access_check["has_access"]:
             raise HTTPException(status_code=403, detail=access_check.get("reason", "Access denied"))
         


### PR DESCRIPTION
Removed leftover debug print statements from document path processing to clean up logs. Fixed the document access check to use the normalized joined path instead of the raw decoded path, ensuring consistent and secure access validation.