### PR TITLE
fix: Correct tools list assignment in AgentOpenAINode

### DIFF
--- a/editor/nodes/xgen/agent/agent_openai.py
+++ b/editor/nodes/xgen/agent/agent_openai.py
@@ -87,7 +87,7 @@ class AgentOpenAINode(Node):
                 agent = create_tool_calling_agent(llm, tools_list, final_prompt)
                 agent_executor = AgentExecutor(
                     agent=agent,
-                    tools=tools,
+                    tools=tools_list,
                     verbose=True,
                     handle_parsing_errors=True,
                     max_iterations=10,


### PR DESCRIPTION
Updated the tools parameter in AgentExecutor to use tools_list instead of tools for proper functionality. This change ensures that the correct list of tools is passed to the agent executor.