### PR TITLE
fix: Enhance document deletion logic to check for existence and owner…

### DIFF
--- a/controller/rag/retrievalController.py
+++ b/controller/rag/retrievalController.py
@@ -643,9 +643,12 @@ async def delete_document_from_collection(request: Request, collection_name: str
         user_id = extract_user_id_from_request(request)
         app_db = get_db_manager(request)
         rag_service = get_rag_service(request)
-        app_db.delete_by_condition(VectorDBChunkMeta, {'document_id': document_id, 'collection_name': collection_name, 'user_id': user_id})
-        app_db.delete_by_condition(VectorDBChunkEdge, {'document_id': document_id, 'collection_name': collection_name, 'user_id': user_id})
-        return rag_service.delete_document_from_collection(collection_name, document_id)
+        meta_result = app_db.delete_by_condition(VectorDBChunkMeta, {'document_id': document_id, 'collection_name': collection_name, 'user_id': user_id})
+        edge_result = app_db.delete_by_condition(VectorDBChunkEdge, {'document_id': document_id, 'collection_name': collection_name, 'user_id': user_id})
+        if meta_result and edge_result:
+            return rag_service.delete_document_from_collection(collection_name, document_id)
+        else:
+            raise HTTPException(status_code=404, detail="Document not found or not owned by user")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to delete document: {str(e)}")
 


### PR DESCRIPTION
This pull request improves the document deletion logic in the `delete_document_from_collection` endpoint by adding error handling to ensure that only existing and user-owned documents can be deleted. Now, if the document metadata or edges are not found or do not belong to the user, a 404 error is returned instead of proceeding with deletion.

**Improvements to deletion logic and error handling:**

* Added checks on the results of `delete_by_condition` for both `VectorDBChunkMeta` and `VectorDBChunkEdge` to ensure the document exists and is owned by the user before proceeding with deletion. If either is missing, a 404 HTTP error is raised. (`controller/rag/retrievalController.py`)…ship before deletion