### PR TITLE
fix: deploy meta bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -337,16 +337,17 @@ async def lifespan(app: FastAPI):
         logger.info("⚙️  Step 9: Workflow data synchronization starting...")
 
         try:
-            sync_result = await workflow_data_synchronizer(app.state.app_db)
-            if sync_result["success"]:
-                logger.info(f"✅ Step 9: Workflow data sync completed successfully! "
-                           f"Added {sync_result['files_added_to_db']} to DB, "
-                           f"Created {sync_result['files_created_from_db']} files, "
-                           f"Removed {sync_result['orphaned_db_entries_removed']} orphaned entries, "
-                           f"Processed {sync_result['users_processed']} users")
-            else:
-                logger.warning(f"⚠️  Step 9: Workflow data sync completed with issues. "
-                             f"Errors: {sync_result.get('errors', [])}")
+            logger.info("🔄 Step 9: SKIPPED - Workflow data sync is currently disabled")
+            # sync_result = await workflow_data_synchronizer(app.state.app_db)
+            # if sync_result["success"]:
+            #     logger.info(f"✅ Step 9: Workflow data sync completed successfully! "
+            #                f"Added {sync_result['files_added_to_db']} to DB, "
+            #                f"Created {sync_result['files_created_from_db']} files, "
+            #                f"Removed {sync_result['orphaned_db_entries_removed']} orphaned entries, "
+            #                f"Processed {sync_result['users_processed']} users")
+            # else:
+            #     logger.warning(f"⚠️  Step 9: Workflow data sync completed with issues. "
+            #                  f"Errors: {sync_result.get('errors', [])}")
         except Exception as e:
             logger.error(f"❌ Step 9: Failed to sync workflow data: {e}")
 


### PR DESCRIPTION
This pull request improves the robustness of workflow-related operations by adding more explicit checks for empty query results, ensuring that code does not assume the presence of data when lists may be empty. It also enhances the workflow duplication process by properly creating or updating associated deployment metadata, and disables the workflow data synchronization step in the application startup sequence.

### Data validation improvements

* Added explicit checks for the existence and non-emptiness of query results (`deploy_data`, `existing_data`, `existing_deploy_data`) before accessing their elements in `save_workflow`, preventing potential runtime errors when lists are empty. [[1]](diffhunk://#diff-6a6766f92fba26d9f9545b3c3952038f20257b4e90991a3d6de39dcd0bce9b54L129-R129) [[2]](diffhunk://#diff-6a6766f92fba26d9f9545b3c3952038f20257b4e90991a3d6de39dcd0bce9b54L169-R175) [[3]](diffhunk://#diff-6a6766f92fba26d9f9545b3c3952038f20257b4e90991a3d6de39dcd0bce9b54L203-R203)

### Workflow duplication enhancements

* Modified `duplicate_workflow` to create or update `DeployMeta` records after duplicating a workflow, ensuring deployment metadata is properly handled for the copied workflow. The code now checks for existing deployment metadata and updates or inserts accordingly.

### Application startup changes

* Disabled the workflow data synchronization step in the application lifespan startup (`main.py`), logging that the sync is skipped and commenting out the previous sync logic.