### PR TITLE
add: prompt_update & group error fix

### DIFF
--- a/controller/authController.py
+++ b/controller/authController.py
@@ -587,13 +587,14 @@ async def get_group_available_sections(request: Request, user_id=None):
         groups = user.groups
         user_type = user.user_type
 
-        groups = [group for group in groups if not group.endswith("__admin__")]
 
         if user_type == "superuser":
             return {"available_sections": available_sections}
 
         if not groups or groups == None or groups == [] or len(groups) == 0:
             return {"available_sections": []}
+
+        groups = [group for group in groups if not group.endswith("__admin__")]
 
         else:
             total_available_sections = []

--- a/controller/promptController.py
+++ b/controller/promptController.py
@@ -146,6 +146,8 @@ async def get_prompt_list(
             }
             prompt_list.append(prompt_data)
 
+        prompt_list.sort(key=lambda x: x.get('updated_at', ''), reverse=True)
+
         response_data = {
             "prompts": prompt_list,
             "total_count": len(prompt_list),


### PR DESCRIPTION
This pull request introduces improvements to user group filtering and prompt list ordering in the controllers. The main changes ensure that admin groups are properly excluded when determining available sections for a user, and that prompts are returned in descending order of their last update time for better relevance.

**User Group Filtering:**
* Moved the filtering of groups that end with `__admin__` to occur after checking for empty groups, ensuring admin groups are excluded only when necessary. (`controller/authController.py`)

**Prompt List Ordering:**
* Added sorting to the prompt list by `updated_at` in descending order, so the most recently updated prompts appear first. (`controller/promptController.py`)