### PR TITLE
refactor: Remove obsolete max memory parameter from config

### DIFF
--- a/constants/base_chat_workflow.json
+++ b/constants/base_chat_workflow.json
@@ -235,17 +235,6 @@
             "step": 1
           },
           {
-            "id": "n_messages",
-            "name": "Max Memory",
-            "type": "INT",
-            "value": 3,
-            "required": false,
-            "optional": true,
-            "min": 1,
-            "max": 10,
-            "step": 1
-          },
-          {
             "id": "base_url",
             "name": "Base URL",
             "type": "STRING",


### PR DESCRIPTION
Deleted the "Max Memory" parameter from the base chat workflow JSON configuration as it is no longer used or required in the current system.